### PR TITLE
Add architecture context in Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,29 +1,66 @@
 # Content decryptor microservice
+This microservice decrypts provided content after authentication by access token.
 
-This microservice can decrypt content, when given three data as input:
+## Why?
 
-- `password` (Provided by the user)
-- `password_hashed` (Predetermined and salted)
-- `content` (The encrypted content)
+In a serverless architecture there's no server to password protect content.  
+Using this microservice you can add the encrypted content to the HTML output without anyone being able to read it.  
+A small Javascript-enhanced form allows you to accept the password from a user, and use this microservice to decrypt it.
 
 ----------------------------------
+
+## Context and flow
+The service can be used in an architecture as described below.
+
+### Site generator
+This process uses the following data:
+- The unencrypted content
+- The `password` that should grant access to the content
+- A secret `salt`, only known by the site generator and the decryptor
+
+It then generates the page frontend, containing:
+- The encrypted content
+- The `hashed password`: the `password` hashed with the secret `salt`
+
+### Client (html + js)
+- Has the encrypted content in the source
+- Has the `hashed password`
+
+It enables a user to fill in their `password`, which should grant access to the encrypted content. After user input, it sends to the decryptor:
+- The encrypted content
+- The `hashed password` (using a salt kept secret from the user)
+- The unencrypted `password` from the user
+
+### Decryptor microservice
+The decryptor doesn't know anything about the content, except for how to decrypt it. After authentication, the decrypted content is returned to the client.
+The decryptor knows the secret `salt`, but not the correct password.
+
+Authentication happens if the user-sent `hashed password` matches `hash (` user-sent `password + salt )`
+
+__________________________________
 
 ## Installation
 
 Install dependencies:
 
-```
+```bash
 $ composer install
 $ yarn install
 ```
 
 Create a `.env` file, based on `.env.example`.
 
-### Why?
+__________________________________
 
-In a serverless architecture there's no server to password protect content.  
-Using this microservice you can add the encrypted content to the HTML output without anyone being able to read it.  
-A small Javascript-enhanced form allows you to accept the password from a user, and use this microservice to decrypt it.
+## Usage
+
+### Decryption
+Decryption will take place when this input is provided:
+
+- `password` (Provided by the user)
+- `password_hashed` (Predetermined and salted)
+- `content` (The encrypted content)
+
 
 ### Encrypting your content
 
@@ -54,13 +91,16 @@ $passwordHashed = password_hash($passwordPlain . $salt, PASSWORD_BCRYPT);
 
 If the salt is added to the `.env` file of this microservice, it will be able to verify the user-provided password.
 
+__________________________________
+
 ## API
 
 Run a local server using
 
-```
+```bash
 $ php -S localhost:8000 -t public
 ```
+__________________________________
 
 ## Deploy
 
@@ -75,20 +115,20 @@ You can use stages to deploy to `development`, `staging` and `production` (defau
 
 ### Deploy staging
 
-```
+```bash
 $ npx serverless deploy --stage staging --env staging 
 ```
 
 ### Deploy production
 
-```
+```bash
 $ npx serverless deploy --stage production --env production 
 ```
 
 Serverless will print the HTTP endpoints to the screen.
 
 
-## Architecture
+## Stack
 
 Built on [Lumen](https://lumen.laravel.com), deployed using [Serverless framework](http://serverless.com/).
 


### PR DESCRIPTION
Added more description on how this service is used in a broader setting, because I don't think it's clear enough now. Perhaps the new section should be further down, though.

More importantly: I think the current terms of `password` and `hashed_password` in `# Parameters` is severely confusing. I ended up calling these `access token` and `access validation hash` - see the new section. Perhaps we can call it that in parameters too? (or a better term if you know one)